### PR TITLE
added transitions feature

### DIFF
--- a/lib/jiralicious/errors.rb
+++ b/lib/jiralicious/errors.rb
@@ -13,4 +13,5 @@ module Jiralicious
   class CaptchaRequired < AuthenticationError; end
   class IssueNotFound < StandardError; end
   class JqlError < StandardError; end
+  class TransitionError < StandardError; end
 end

--- a/lib/jiralicious/issue.rb
+++ b/lib/jiralicious/issue.rb
@@ -27,5 +27,30 @@ module Jiralicious
 
       new(response)
     end
+
+    def self.get_transitions(transitions_url)
+      response = Jiralicious.session.perform_request do
+        Jiralicious::Session.get(transitions_url)
+      end
+      JSON.parse(response.body)
+    end
+
+    def self.transition(transitions_url, data)
+      response = Jiralicious.session.perform_request do
+        Jiralicious::Session.post(transitions_url, :body => data.to_json)
+      end
+
+      case response.code
+      when 204
+        response.body
+      when 400
+        error = JSON.parse(response.body)
+        raise Jiralicious::TransitionError.new(error['errorMessages'].join('\n'))
+      when 404
+        error = JSON.parse(response.body)
+        raise Jiralicious::IssueNotFound.new(error['errorMessages'].join('\n'))
+      end
+    end
+
   end
 end

--- a/spec/fixtures/transitions.json
+++ b/spec/fixtures/transitions.json
@@ -1,0 +1,65 @@
+{
+    "2": {
+        "name": "Close Issue",
+        "fields": [{
+            "id": "resolution",
+            "required": true,
+            "type": "com.atlassian.jira.issue.resolution.Resolution"
+        },
+        {
+            "id": "fixVersions",
+            "required": false,
+            "type": "com.atlassian.jira.project.version.Version"
+        },
+        {
+            "id": "customfield_10105",
+            "required": false,
+            "type": "com.atlassian.jira.plugins.jira-importers-plugin:bug-importid"
+        },
+        {
+            "id": "customfield_10106",
+            "required": false,
+            "type": "com.atlassian.jira.plugin.system.customfieldtypes:textfield"
+        },
+        {
+            "id": "assignee",
+            "required": false,
+            "type": "com.opensymphony.user.User"
+        }],
+        "transitionDestination": "6"
+    },
+    "4": {
+        "name": "Start Progress",
+        "fields": [],
+        "transitionDestination": "3"
+    },
+    "5": {
+        "name": "Resolve Issue",
+        "fields": [{
+            "id": "resolution",
+            "required": true,
+            "type": "com.atlassian.jira.issue.resolution.Resolution"
+        },
+        {
+            "id": "fixVersions",
+            "required": false,
+            "type": "com.atlassian.jira.project.version.Version"
+        },
+        {
+            "id": "customfield_10105",
+            "required": false,
+            "type": "com.atlassian.jira.plugins.jira-importers-plugin:bug-importid"
+        },
+        {
+            "id": "customfield_10106",
+            "required": false,
+            "type": "com.atlassian.jira.plugin.system.customfieldtypes:textfield"
+        },
+        {
+            "id": "assignee",
+            "required": false,
+            "type": "com.opensymphony.user.User"
+        }],
+        "transitionDestination": "5"
+    }
+}

--- a/spec/issue_spec.rb
+++ b/spec/issue_spec.rb
@@ -37,3 +37,60 @@ describe Jiralicious::Issue, "finding" do
     issue.jira_self.should == "http://example.com:8080/jira/rest/api/2.0/issue/EX-1"
   end
 end
+
+
+describe Jiralicious::Issue, "transitions" do
+
+  before :each do
+    Jiralicious.configure do |config|
+      config.username = "jstewart"
+      config.password = "topsecret"
+      config.uri = "http://localhost"
+      config.api_version = "latest"
+    end
+
+  end
+
+  it "returns list of possible transitions" do
+    FakeWeb.register_uri(:get,
+                         "#{Jiralicious.rest_path}/issue/EX-1/transitions",
+                         :status => "200",
+                         :body => transitions_json)
+
+    transitions = Jiralicious::Issue.get_transitions("#{Jiralicious.rest_path}/issue/EX-1/transitions")
+    transitions.should be_instance_of(Hash)
+  end
+
+  it "performs transition" do
+    FakeWeb.register_uri(:post,
+                         "#{Jiralicious.rest_path}/issue/EX-1/transitions",
+                         :status => "204",
+                         :body => nil)
+
+    result = Jiralicious::Issue.transition("#{Jiralicious.rest_path}/issue/EX-1/transitions",
+                                  {"transition" => "3", "fields" => []})
+    result.should be_empty
+  end
+
+  it "raises an exception on transition failure" do
+    FakeWeb.register_uri(:post,
+                         "#{Jiralicious.rest_path}/issue/EX-1/transitions",
+                         :status => "400",
+                         :body => %q{{"errorMessages":["Workflow operation is not valid"],"errors":{}}})
+    lambda {
+      result = Jiralicious::Issue.transition("#{Jiralicious.rest_path}/issue/EX-1/transitions",
+                                    {"transition" => "invalid"})
+    }.should raise_error(Jiralicious::TransitionError)
+  end
+
+  it "raises an IssueNotFound exception if issue is not found" do
+    FakeWeb.register_uri(:post,
+                         "#{Jiralicious.rest_path}/issue/EX-1/transitions",
+                         :status => "404",
+                         :body => %q{{"errorMessages":["Issue Does Not Exist"],"errors":{}}})
+    lambda {
+      result = Jiralicious::Issue.transition("#{Jiralicious.rest_path}/issue/EX-1/transitions",
+                                    {"transition" => "invalid"})
+    }.should raise_error(Jiralicious::IssueNotFound)
+  end
+end

--- a/spec/support/http.rb
+++ b/spec/support/http.rb
@@ -27,4 +27,8 @@ module JsonResponse
   def search_json
     File.new(File.expand_path('search.json', File.dirname(__FILE__) + '/../fixtures')).read
   end
+
+  def transitions_json
+    File.new(File.expand_path('transitions.json', File.dirname(__FILE__) + '/../fixtures')).read
+  end
 end


### PR DESCRIPTION
Jiralicious::Issue.get_transitions(transition_url) returns a list of possible transitions
Jiralicious::Issue.transition(transition_url, {"transition" => "3", "fields" => []}) performs actual transition

transition method raises Jiralicious::TransitionError if there is any error performing the transition
also Jiralicious::IssueNotFound is raised if the issue is not found
