### PR TITLE
no longer parse HTTParty response when raising errors

### DIFF
--- a/lib/jiralicious/base.rb
+++ b/lib/jiralicious/base.rb
@@ -102,11 +102,11 @@ module Jiralicious
           when 200..204
             response
           when 400
-            raise Jiralicious::TransitionError.new(response['errorMessages'].join('\n'))
+            raise Jiralicious::TransitionError.new(response)
           when 404
-            raise Jiralicious::IssueNotFound.new(response['errorMessages'].join('\n'))
+            raise Jiralicious::IssueNotFound.new(response)
           else
-            raise Jiralicious::JiraError.new(response['errorMessages'].join('\n'))
+            raise Jiralicious::JiraError.new(response)
           end
         end
       end


### PR DESCRIPTION
This fixes my problem in issue https://github.com/jstewart/jiralicious/issues/18

I believe that Jiralicious should return the full response rather than just a parsed message from it. This allows client libraries to include better error handling, and allows greater flexibility as the jira api changes. I was getting a blank error message.

This might break things for people who were trying to parse the error message. However, the information they wanted will still be there, but they will have the option of parsing the message themselves.

My client code looks something like this with the change.

``` ruby
begin
  method_that_causes_transition_error
rescue => e
  log "#{e.message}"  #=> "{"errorMessages"=>[], "errors"=>{"summary"=>"The summary is invalid because it contains newline characters."}}"
end
```
