### PR TITLE
Don't limit the version of httparty to hard

### DIFF
--- a/jiralicious.gemspec
+++ b/jiralicious.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email = "jstewart@fusionary.com"
   s.authors = ["Jason Stewart"]
   s.add_runtime_dependency 'crack', '~> 0.1.8'
-  s.add_runtime_dependency 'httparty', '>= 0.10', '< 0.12.0'
+  s.add_runtime_dependency 'httparty', '>= 0.10'
   s.add_runtime_dependency 'hashie', '>= 1.1'
   s.add_runtime_dependency 'json', '>= 1.6', '< 1.9.0'
   s.add_development_dependency 'rspec', '~> 2.6'


### PR DESCRIPTION
It shouldn't be necessary to limit httparty to < 0.12.0.
