### PR TITLE
Restrict hashie to v 2.1.x to avoid symbol vs. string problems in proper...

### DIFF
--- a/jiralicious.gemspec
+++ b/jiralicious.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.authors = ["Jason Stewart"]
   s.add_runtime_dependency 'crack', '~> 0.1.8'
   s.add_runtime_dependency 'httparty', '>= 0.10', '< 0.12.0'
-  s.add_runtime_dependency 'hashie', '>= 1.1'
+  s.add_runtime_dependency 'hashie', '~> 2.1'
   s.add_runtime_dependency 'json', '>= 1.6', '< 1.9.0'
   s.add_development_dependency 'rspec', '~> 2.6'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Hi!  I restricted the hashie gem version because the 3.0.0 version was giving "property '…' is not defined in this Trash" errors.  I tried adding a require Hashie::Extensions::Dash::IndifferentAccess, which helped, but it still failed on "self."
