### PR TITLE
Add "<3" constraint to hashie gem.

### DIFF
--- a/jiralicious.gemspec
+++ b/jiralicious.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.authors = ["Jason Stewart"]
   s.add_runtime_dependency 'crack', '~> 0.1.8'
   s.add_runtime_dependency 'httparty', '>= 0.10', '< 0.12.0'
-  s.add_runtime_dependency 'hashie', '>= 1.1'
+  s.add_runtime_dependency 'hashie', '>= 1.1', '< 3'
   s.add_runtime_dependency 'json', '>= 1.6', '< 1.9.0'
   s.add_development_dependency 'rspec', '~> 2.6'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
This appears to solve the problem of a Hashie version resulting in errors such as this one:

```
/Users/kbennett/.rvm/gems/ruby-1.9.3-p448@jiradox/gems/hashie-3.0.0/lib/hashie/trash.rb:80:in `property_exists?': The property 'expand' is not defined for this Trash. (NoMethodError)
    from /Users/kbennett/.rvm/gems/ruby-1.9.3-p448@jiradox/gems/hashie-3.0.0/lib/hashie/trash.rb:49:in `[]='
```
