### PR TITLE
Allow numbers in project keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,8 @@ rvm:
 gemfile:
   - gemfiles/oldest.gemfile
   - gemfiles/newest.gemfile
+
+# Travis CI has an outdated version of bundler on older versions of ruby.
+# See bundler/bundler#3558 for more information
+before_install:
+  - gem update bundler

--- a/lib/jiralicious/base.rb
+++ b/lib/jiralicious/base.rb
@@ -144,7 +144,7 @@ module Jiralicious
       #
       #
       def issueKey_test(key, no_throw = false)
-        if key.nil? || !(/^[A-Z]+-[0-9]+$/i =~ key)
+        if key.nil? || !(/^[A-Z][A-Z0-9_]*-[0-9]+$/i =~ key)
           raise Jiralicious::JiraError.new("The key #{key} is invalid") unless no_throw
           return false
         end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1,0 +1,33 @@
+# encoding: utf-8
+require "spec_helper"
+
+describe Jiralicious::Base, "issue keys" do
+  it "can contains all capital letters" do
+    expect(Jiralicious::Base.issueKey_test("ABC-1", true)).to eq true
+  end
+
+  it "can contain a capital letter followed by numbers and underscores" do
+    expect(Jiralicious::Base.issueKey_test("ABC_01-1", true)).to eq true
+  end
+
+  it "raises an exception on invalid keys by default" do
+    expect { Jiralicious::Base.issueKey_test("1-invalid") }.
+      to raise_error("The key 1-invalid is invalid")
+  end
+
+  it "must start with a letter" do
+    expect(Jiralicious::Base.issueKey_test("2013PROJECT-1", true)).to eq false
+  end
+
+  it "must not contain characters other than A-Z, 0-9, and _" do
+    expect(Jiralicious::Base.issueKey_test("ABC@-1", true)).to eq false
+  end
+
+  it "must have an issue number following the project key" do
+    expect(Jiralicious::Base.issueKey_test("ABC", true)).to eq false
+  end
+
+  it "must have an issue number that is only digits" do
+    expect(Jiralicious::Base.issueKey_test("ABC-A", true)).to eq false
+  end
+end


### PR DESCRIPTION
JIRA project keys can contain capital letters, numbers, and underscores, but the Jiralicious issue key validator only allows it to have multiple capital letters.  We use a project key, PT2, which is causing some scripts we have using Jiralicious to break.

https://confluence.atlassian.com/adminjiraserver071/changing-the-project-key-format-802592378.html

This PR just loosens the project key validation, as well as adding some basic tests for issue key validity.
