### PR TITLE
Allow project keys to include numbers e.g. N80X-123

### DIFF
--- a/lib/jiralicious/base.rb
+++ b/lib/jiralicious/base.rb
@@ -144,7 +144,7 @@ module Jiralicious
       #
       #
       def issueKey_test(key, no_throw = false)
-        if key.nil? || !(/^[A-Z]+-[0-9]+$/i =~ key)
+        if key.nil? || !(/^[A-Z0-9]+-[0-9]+$/i =~ key)
           raise Jiralicious::JiraError.new("The key #{key} is invalid") unless no_throw
           return false
         end


### PR DESCRIPTION
N80X is a valid project key in jira. When you attempt to lookup an issue for that project, the issueKey_test validation fails
