### PR TITLE
Fix issue.save for new issues

### DIFF
--- a/lib/jiralicious/issue/fields.rb
+++ b/lib/jiralicious/issue/fields.rb
@@ -191,7 +191,7 @@ module Jiralicious
       # for Jira to perform an create request.
       #
       def format_for_create
-        { "fields" => @fields_update }
+        { "fields" => @fields_current }
       end
     end
   end


### PR DESCRIPTION
If the issue is new, then the fields are not being updated, they are being created.

```
new_issue_data = {
  'fields' => {
    'reporter' => {
      'name' => 'username'
    },
    'project' => {
      'key' => 'KEY'
    },
    'issuetype' => {
      'name' => 'Task'
    },
    'summary' => 'Testing ticket',
    'description' => 'blah blah blah'
  }
}

new_issue = Jiralicious::Issue.new(new_issue_data)
saved_issue = new_issue.save!
```

The above code results in 400 from Jira due to the fields hash being empty
```
Jiralicious::TransitionError: #<HTTParty::Response:0x7ffd32d57730 parsed_response={"errorMessages"=>[], "errors"=>{"project"=>"project is required"}}, @response=#<Net::HTTPBadRequest 400 Bad Request readbody=true>, ...
```

Options hash from just before the API call in `Jiralicious::Base#fetch`
```
{:method=>:post, :body=>{"fields"=>{}}, :body_uri=>{"fields"=>{}}, :url_uri=>"https://example.atlassian.net/rest/api/latest/issue/"}
```